### PR TITLE
Add support for PHP 8

### DIFF
--- a/src/EventableFilesystem.php
+++ b/src/EventableFilesystem.php
@@ -428,7 +428,7 @@ class EventableFilesystem extends Filesystem
     protected function callFilesystemMethod($method, array $arguments)
     {
         $callable = 'parent::'.$method;
-        $result = call_user_func_array($callable, $arguments);
+        $result = call_user_func_array($callable, array_values($arguments));
 
         return $result;
     }


### PR DESCRIPTION
Using an associative array with `call_user_func_array()` worked prior to PHP 8 but is now used to pass named arguments. 